### PR TITLE
create-buildbot-user.ps1: Set password to never expire

### DIFF
--- a/scripts/create-buildbot-user.ps1
+++ b/scripts/create-buildbot-user.ps1
@@ -1,5 +1,5 @@
 param ([string] $password)
 
 $buildbot_user_password = ConvertTo-SecureString $password -AsPlainText -Force
-New-LocalUser -AccountNeverExpires -Description "buildbot" -FullName "buildbot" -Name "buildbot" -Password $buildbot_user_password
+New-LocalUser -AccountNeverExpires -PasswordNeverExpires -Description "buildbot" -FullName "buildbot" -Name "buildbot" -Password $buildbot_user_password
 & net localgroup administrators buildbot /add


### PR DESCRIPTION
When using the buildnode for more than 42 days (the default
password expiry in Windows Server 2019) it becomes inoperable.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>