### PR TITLE
buildbot-host: ensure that /var/lib/repos is shared with buildmaster

### DIFF
--- a/buildbot-host/buildmaster/launch.sh
+++ b/buildbot-host/buildmaster/launch.sh
@@ -15,4 +15,4 @@ fi
 docker container stop buildmaster
 docker container rm buildmaster
 
-docker container run -it --name buildmaster --restart no --mount source=buildmaster,target=/var/lib/buildbot/masters/default/persistent --network buildbot-net --publish 8010:8010 --publish 9989:9989 openvpn_community/buildmaster:$TAG
+docker container run -it --name buildmaster --restart no --volume /var/lib/repos:/var/lib/repos --mount source=buildmaster,target=/var/lib/buildbot/masters/default/persistent --network buildbot-net --publish 8010:8010 --publish 9989:9989 openvpn_community/buildmaster:$TAG

--- a/buildbot-host/provision.sh
+++ b/buildbot-host/provision.sh
@@ -31,6 +31,10 @@ docker network create --driver bridge buildbot-net
 # Create volume for storing buildmaster's sqlite database and passwords
 docker volume create buildmaster
 
+# Create a directory for local Git repositories shared from the Docker host to
+# the buildmaster container
+mkdir -p /var/lib/repos
+
 # Add secrets
 mkdir -p $VOLUME_DIR/secrets
 chmod 700 $VOLUME_DIR/secrets


### PR DESCRIPTION
This allows having local staging Git repositories that can be used with
force builds to test out patches or to stage fixes to security
vulnerabilities.

Signed-off-by: Samuli Seppänen <samuli@openvpn.net>