### PR TITLE
buildmaster: upgrade to buildbot v3.5.0

### DIFF
--- a/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-alpine-3/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=alpine:3.13.6
 ARG DEPS_SH=install-openvpn-build-deps-alpine.sh
 ARG MY_NAME="buildbot-worker-alpine-3"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-arch/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-arch/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=docker.io/library/archlinux:latest
 ARG DEPS_SH=install-openvpn-build-deps-arch.sh
 ARG MY_NAME="buildbot-worker-arch"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="master"

--- a/buildbot-host/buildbot-worker-centos-7/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-centos-7/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=centos:7
 ARG DEPS_SH=install-openvpn-build-deps-centos-7.sh
 ARG MY_NAME="buildbot-worker-centos-7"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-debian-10-static/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-10-static/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=debian:10
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-10"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-debian-10/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-10/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=debian:10
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-10"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-debian-11/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-11/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=debian:11
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-11"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-debian-unstable/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=debian:unstable
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-debian-unstable"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="master"

--- a/buildbot-host/buildbot-worker-fedora-34/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-34/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=fedora:34
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-34"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-fedora-35/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-35/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=fedora:35
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-35"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-fedora-rawhide/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-fedora-rawhide/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=fedora:rawhide
 ARG DEPS_SH=install-openvpn-build-deps-fedora.sh
 ARG MY_NAME="buildbot-worker-fedora-rawhide"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-opensuse-leap-15/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-opensuse-leap-15/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=opensuse/leap:15
 ARG DEPS_SH=install-openvpn-build-deps-opensuse-leap.sh
 ARG MY_NAME="buildbot-worker-opensuse-leap-15"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-1804/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-1804/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=ubuntu:18.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-1804"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-2004/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2004/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=ubuntu:20.04
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2004"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildbot-worker-ubuntu-2110/Dockerfile.base
+++ b/buildbot-host/buildbot-worker-ubuntu-2110/Dockerfile.base
@@ -1,5 +1,5 @@
 ARG IMAGE=ubuntu:21.10
 ARG DEPS_SH=install-openvpn-build-deps-ubuntu.sh
 ARG MY_NAME="buildbot-worker-ubuntu-2110"
-ARG MY_VERSION="v1.0.0"
+ARG MY_VERSION="v1.0.1"
 ARG ASIO_REF="asio-1-18-2"

--- a/buildbot-host/buildmaster/Dockerfile
+++ b/buildbot-host/buildmaster/Dockerfile
@@ -1,6 +1,6 @@
 ARG MY_NAME="buildmaster"
-ARG MY_VERSION="v2.0.0"
-ARG IMAGE=buildbot/buildbot-master:v3.1.0
+ARG MY_VERSION="v2.1.0"
+ARG IMAGE=buildbot/buildbot-master:v3.5.0
 
 FROM $IMAGE
 
@@ -13,9 +13,9 @@ ENV BASEDIR=/var/lib/buildbot/masters/default
 RUN mkdir -p $BASEDIR
 
 # Required for latent docker buildslaves
-RUN pip3 install docker
+RUN . /buildbot_venv/bin/activate && pip install docker || false
 RUN set -ex; \
-    apk add patch
+    apt-get update && apt-get -y install patch || false
 
 COPY buildmaster/buildbot.tac $BASEDIR
 COPY buildmaster/start_buildmaster.sh $BASEDIR
@@ -39,7 +39,7 @@ ADD buildmaster/openvpn3-linux $BASEDIR/openvpn3-linux
 ADD buildmaster/ovpn-dco $BASEDIR/ovpn-dco
 
 RUN set -ex; \
-    patch /usr/lib/python3.8/site-packages/buildbot/steps/vstudio.py $BASEDIR/vstudio.py.patch
+    patch /buildbot_venv/lib/python3.9/site-packages/buildbot/steps/vstudio.py $BASEDIR/vstudio.py.patch
 
 COPY scripts/ensure-tun-is-present.sh $BASEDIR
 

--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -402,8 +402,9 @@ generator = reporters.BuildStatusGenerator(
     message_formatter=reporters.MessageFormatter(
         template_type='plain',
         template=template,
-        wantSteps=True,
-        wantLogs=True,
+        want_steps=True,
+        want_logs=True,
+        want_logs_content=True,
     ))
 
 mn = reporters.MailNotifier(fromaddr=fromaddr,

--- a/buildbot-host/buildmaster/start_buildmaster.sh
+++ b/buildbot-host/buildmaster/start_buildmaster.sh
@@ -9,6 +9,8 @@ rm -f $B/twistd.pid
 
 #BUILDBOT_CONFIG_DIR=$B
 
+. /buildbot_venv/bin/activate
+
 # wait for db to start by trying to upgrade the master
 until buildbot upgrade-master $B
 do

--- a/buildbot-host/buildmaster/vstudio.py.patch
+++ b/buildbot-host/buildmaster/vstudio.py.patch
@@ -1,11 +1,10 @@
---- vstudio.py.orig	2021-06-22 08:07:48.732917001 +0000
-+++ vstudio.py	2021-06-22 08:09:33.370637468 +0000
-@@ -532,7 +532,7 @@
+--- vstudio.py.orig     2022-07-21 16:11:41.344464416 +0000
++++ vstudio.py  2022-07-21 16:12:50.169360429 +0000
+@@ -557,7 +557,7 @@
          self.descriptionDone = 'built ' + self.describe_project()
          yield self.updateSummary()
- 
--        command = (('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\')" '
-+        command = (('FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property  installationPath\')" '
-                     ' do "%%I\\%VCENV_BAT%" x86 && msbuild "{}" /p:Configuration="{}" '
-                     '/p:Platform="{}" /maxcpucount').format(self.projectfile, self.config,
-                                                             self.platform))
+
+-        command = ('FOR /F "tokens=*" %%I in (\'vswhere.exe -property  installationPath\') '
++        command = ('FOR /F "tokens=*" %%I in (\'vswhere.exe -products * -property  installationPath\') '
+                    f' do "%%I\\%VCENV_BAT%" x86 && msbuild "{self.projectfile}" '
+                    f'/p:Configuration="{self.config}" /p:Platform="{self.platform}" /maxcpucount')

--- a/buildbot-host/buildmaster/worker-default.ini
+++ b/buildbot-host/buildmaster/worker-default.ini
@@ -19,28 +19,28 @@ openvpn3_linux_extra_config_opts=
 openvpn3_linux_command_prefix=["/bin/sh", "-c"]
 
 [centos-7]
-image=openvpn_community/buildbot-worker-centos-7:v1.0.0
+image=openvpn_community/buildbot-worker-centos-7:v1.0.1
 openvpn3_linux_command_prefix=["/bin/sh", "--login", "-c"]
 openvpn3_linux_extra_config_opts=--disable-unit-tests
 # asio in CentOS 7 is too old to work with openvpn3
 enable_openvpn3_builds=false
 
 [debian-10]
-image=openvpn_community/buildbot-worker-debian-10:v1.0.0
+image=openvpn_community/buildbot-worker-debian-10:v1.0.1
 enable_ovpn-dco_builds=false
 
 [debian-11]
-image=openvpn_community/buildbot-worker-debian-11:v1.0.0
+image=openvpn_community/buildbot-worker-debian-11:v1.0.1
 
 [debian-unstable]
-image=openvpn_community/buildbot-worker-debian-unstable:v1.0.0
+image=openvpn_community/buildbot-worker-debian-unstable:v1.0.1
 
 [arch]
-image=openvpn_community/buildbot-worker-arch:v1.0.0
+image=openvpn_community/buildbot-worker-arch:v1.0.1
 enable_debian_builds=false
 
 [fedora-34]
-image=openvpn_community/buildbot-worker-fedora-34:v1.0.0
+image=openvpn_community/buildbot-worker-fedora-34:v1.0.1
 enable_debian_builds=false
 
 # Fedora 35+ is disabled until this bug is fixed:
@@ -56,25 +56,25 @@ enable_debian_builds=false
 #enable_debian_builds=false
 
 [opensuse-leap-15]
-image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.0
+image=openvpn_community/buildbot-worker-opensuse-leap-15:v1.0.1
 enable_debian_builds=false
 # Kernel headers are not usable on this platform out of the box
 enable_ovpn-dco_builds=false
 
 [ubuntu-1804]
-image=openvpn_community/buildbot-worker-ubuntu-1804:v1.0.0
+image=openvpn_community/buildbot-worker-ubuntu-1804:v1.0.1
 enable_mbedtls_builds=false
 enable_ovpn-dco_builds=false
 
 [ubuntu-2004]
-image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.0
+image=openvpn_community/buildbot-worker-ubuntu-2004:v1.0.1
 
 [ubuntu-2004-vm-static]
 type=normal
 ostype=unix
 
 [ubuntu-2110]
-image=openvpn_community/buildbot-worker-ubuntu-2110:v1.0.0
+image=openvpn_community/buildbot-worker-ubuntu-2110:v1.0.1
 
 [windows-server-2019-static]
 type=normal

--- a/buildbot-host/scripts/install-buildbot.sh
+++ b/buildbot-host/scripts/install-buildbot.sh
@@ -4,7 +4,7 @@
 #
 set -ex
 
-BUILDBOT_VERSION=3.1.0
+BUILDBOT_VERSION=3.5.0
 
 pip3 install --upgrade pip && \
 pip --no-cache-dir install twisted[tls] && \


### PR DESCRIPTION
- Docker image is now based on Debian 11 and
  python packages are installed in virtualenv.
- Update vstudio.py patch.
- Resolve some deprecation warnings.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>