### PR TITLE
openvpn3: add xxHash dependency to workers

### DIFF
--- a/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-arch.sh
@@ -42,6 +42,7 @@ python-setuptools \
 python-wheel \
 tinyxml2 \
 which \
+xxhash \
 zlib
 
 # Hack to ensure that kernel headers can be found from a predictable place

--- a/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-fedora.sh
@@ -45,6 +45,7 @@ python3-wheel \
 selinux-policy-devel \
 tinyxml2-devel \
 which \
+xxhash-devel \
 zlib-devel
 
 # Hack to ensure that kernel headers can be found from a predictable place

--- a/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-opensuse-leap.sh
@@ -45,7 +45,8 @@ python3-pip \
 python3-pyOpenSSL \
 python3-setuptools \
 python3-wheel \
-tinyxml2-devel
+tinyxml2-devel \
+xxhash-devel
 
 # Hack to ensure that kernel headers can be found from a predictable place
 # Right now kernel headers are not usable with ovpn-dco, so this is here mostly

--- a/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
+++ b/buildbot-host/scripts/install-openvpn-build-deps-ubuntu.sh
@@ -50,6 +50,7 @@ libsystemd-dev \
 libtool \
 libtinyxml2-dev \
 libxml2-utils \
+libxxhash-dev \
 make \
 net-tools \
 pkg-config \


### PR DESCRIPTION
Now required by some unit tests.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>