### PR TITLE
buildmaster: listen on IPv6

### DIFF
--- a/buildbot-host/buildmaster/master.cfg
+++ b/buildbot-host/buildmaster/master.cfg
@@ -122,7 +122,7 @@ for worker_name in worker_names:
                             notify_on_missing=notify_on_missing,
                             properties = { 'signing_cert_password': get_worker_setting(worker_config, worker_name, 'signing_cert_password'), 'signing_cert_sha1': get_worker_setting(worker_config, worker_name, 'signing_cert_sha1'), 'timestamp_url': get_worker_setting(worker_config, worker_name, 'timestamp_url')}))
 
-c['protocols'] = {'pb': {'port': 9989}}
+c['protocols'] = {'pb': {'port': r"tcp:interface=\:\:0:port=9989"}}
 
 c['change_source'] = []
 
@@ -420,7 +420,7 @@ c['title'] = "OpenVPN buildbot"
 c['titleURL'] = title_url
 c['buildbotURL'] = buildbot_url
 c['www'] = {
-    'port': 8010,
+    'port': r"tcp:interface=\:\:0:port=8010",
     'plugins': { 'waterfall_view': True, }
 }
 


### PR DESCRIPTION
This also supports IPv4.

Otherwise it only listens on the IPv4 address, which
breaks IPv6 access.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>