### PR TITLE
t_client.rc: enable IPv6-remote tests

### DIFF
--- a/buildbot-host/t_client/t_client.rc
+++ b/buildbot-host/t_client/t_client.rc
@@ -40,7 +40,7 @@ REMOTE4=199.102.77.82
 #
 # tests to run (list suffixes for config stanzas below)
 #
-TEST_RUN_LIST="1 2 2a 2f 3 4 4b 5 6"
+TEST_RUN_LIST="1 1a 2 2a 2b 2c 2f 3 4 4a 4b 5 6"
 #TEST_RUN_LIST="1 1a 1b 1c 1d 1e 2 2a 2b 2c 2d 2e 2f 3 4 4a 4b 5 6 8 8a 9 9a 9b 9x 11 11a"
 #TEST_RUN_LIST="1 1a 2 3"
 #TEST_RUN_LIST="1a"


### PR DESCRIPTION
Enable tests that talk to the remote via IPv6.
buildbot-host docker workers have IPv6 connectivity
now.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>