### PR TITLE
jenkins: Update to Java 11

### DIFF
--- a/jenkins/jenkins-agent-windows-server-2019/ec2.pkr.hcl
+++ b/jenkins/jenkins-agent-windows-server-2019/ec2.pkr.hcl
@@ -59,7 +59,7 @@ source "amazon-ebs" "windows-server-2019" {
 build {
   source "amazon-ebs.windows-server-2019" {
     name     = "jenkins-agent-windows-server-2019"
-    ami_name = "jenkins-agent-windows-server-2019-1"
+    ami_name = "jenkins-agent-windows-server-2019-2"
   }
 
   provisioner "file" {

--- a/scripts/jenkins-agent.ps1
+++ b/scripts/jenkins-agent.ps1
@@ -8,7 +8,7 @@ param ([string] $workdir,
 
 Write-Host "Setting up Jenkins agent"
 
-& choco.exe install -y openjdk8
+& choco.exe install -y openjdk11
 CheckLastExitCode
 
 if (-Not (Test-Path $workdir)) {


### PR DESCRIPTION
Java 8 is not supported by newest Jenkins LTS
anymore.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>