### PR TITLE
t_client fix for 2a in 2.5.x

### DIFF
--- a/buildbot-host/t_client/t_client.rc
+++ b/buildbot-host/t_client/t_client.rc
@@ -169,7 +169,7 @@ PING6_HOSTS_2="fd00:abcd:194:2::1 fd00:abcd:194:0::1"
 
 #RUN_TITLE_2a="udp / p2pm / v6-only / --multihome / --ncp-disable"
 RUN_TITLE_2a="udp / p2pm / v6-only / --multihome"
-OPENVPN_CONF_2a="$OPENVPN_BASE_P2MP --dev tun --proto udp4 --remote $REMOTE --port 51194 --route-nopull --route-ipv6 fd00:abcd:194::/48 --multihome --cipher BF-CBC --data-ciphers BF-CBC --providers legacy default"
+OPENVPN_CONF_2a="$OPENVPN_BASE_P2MP --dev tun --proto udp4 --remote $REMOTE --port 51194 --route-nopull --route-ipv6 fd00:abcd:194::/48 --multihome --nobind --cipher BF-CBC --data-ciphers BF-CBC --providers legacy default"
 # geht nicht auf FreeBSD
 #if [ `uname -o` = "GNU/Linux" ] ; then
 #    OPENVPN_CONF_2a="$OPENVPN_CONF_2a --mtu-disc yes"


### PR DESCRIPTION
Add --nobind to t_client test 2a. At least some versions of openvpn server do not handle tests 2 and 2a correctly and assume that the client in 2a is a renegotiation instead of a new connection. Use --nobind to avoid this.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>