### PR TITLE
install-buildbot.sh: hard-code cryptography dependency version

### DIFF
--- a/buildbot-host/scripts/install-buildbot.sh
+++ b/buildbot-host/scripts/install-buildbot.sh
@@ -6,7 +6,9 @@ set -ex
 
 BUILDBOT_VERSION=3.5.0
 
+# hardcode cryptography version since newer don't work on CentOS 7
 pip3 install --upgrade pip && \
+pip --no-cache-dir install cryptography==37.0.4 && \
 pip --no-cache-dir install twisted[tls] && \
 pip --no-cache-dir install buildbot_worker==$BUILDBOT_VERSION
 


### PR DESCRIPTION
Version 38 doesn't work with the OpenSSL version in CentOS 7.

Signed-off-by: Frank Lichtenheld <frank@lichtenheld.com>